### PR TITLE
Allow Nightmare 3.0+ as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Mr0grog/nightmare-real-mouse#readme",
   "peerDependencies": {
-    "nightmare": "^2.10.0"
+    "nightmare": ">=2.10.0 <4.0"
   },
   "devDependencies": {
     "chai": "^4.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -127,6 +127,28 @@ describe('real-mouse', function() {
           expect(title).to.equal('Submitted Page');
         });
     });
+    
+    it('should reject if the selector is not found', function() {
+      return nightmare
+        .goto(`${baseUrl}/simple`)
+        .realClick('#does-not-exist')
+        .then(() => {
+          throw new Error('Using a non-existent selector did not reject');
+        }, error => {
+          expect(error.message).to.equal('Cannot find element: "#does-not-exist"');
+        });
+    });
+    
+    it('should reject if the selector was not a string', function() {
+      return nightmare
+        .goto(`${baseUrl}/simple`)
+        .realClick(5)
+        .then(() => {
+          throw new Error('Using a non-string selector did not reject');
+        }, error => {
+          expect(error.message).to.have.string('"selector" must be a string');
+        });
+    });
   });
   
   describe('realMouseover', function() {
@@ -186,6 +208,17 @@ describe('real-mouse', function() {
           ]);
         });
     });
+    
+    it('should reject the nightmare promise if the selector is not found', function() {
+      return nightmare
+        .goto(`${baseUrl}/simple`)
+        .realMouseover('#does-not-exist')
+        .then(() => {
+          throw new Error('Using a non-existent selector did not reject');
+        }, error => {
+          expect(error.message).to.equal('Cannot find element: "#does-not-exist"');
+        });
+    });
   });
   
   describe('realMousedown', function() {
@@ -216,6 +249,17 @@ describe('real-mouse', function() {
             'mouseenter on first',
             'mousedown on first'
           ]);
+        });
+    });
+    
+    it('should reject the nightmare promise if the selector is not found', function() {
+      return nightmare
+        .goto(`${baseUrl}/simple`)
+        .realMousedown('#does-not-exist')
+        .then(() => {
+          throw new Error('Using a non-existent selector did not reject');
+        }, error => {
+          expect(error.message).to.equal('Cannot find element: "#does-not-exist"');
         });
     });
   });


### PR DESCRIPTION
The 3.0.0 changelog mentioned breaking changes related to argument order for errors, but it turns out they didn’t actually affect any of the code here. Just in case, I’ve added tests around error cases.

Fixes #34.

If you’re still interested in this, @xeBuz, feel free to test and make sure it still works right for you.